### PR TITLE
feat: show comment on hover

### DIFF
--- a/server/src/server/symbols/symbol-operations.ts
+++ b/server/src/server/symbols/symbol-operations.ts
@@ -860,7 +860,7 @@ export class SymbolOperations implements ISymbolOperations {
             // Regex: Find "//" that is NOT at the start of the line (checked by code context logic usually,
             // but here we assume the symbol exists on this line).
             // We capture everything after //, optionally stripping < or ! if it's Doxygen style
-            const trailingMatch = currentLine.match(/[^\/](\/\/[!/<]*\s*)(.*)$/);
+            const trailingMatch = currentLine.match(/[^/](\/\/[!/<]*\s*)(.*)$/);
 
             if (trailingMatch && trailingMatch[2]) {
                 const rawComment = trailingMatch[2].trim();
@@ -871,7 +871,7 @@ export class SymbolOperations implements ISymbolOperations {
             }
 
             // Check for Preceding Comments (Go upwards)
-            let docLines: string[] = [];
+            const docLines: string[] = [];
             let inCommentBlock = false;
 
             for (let i = startLine - 1; i >= 0; i--) {


### PR DESCRIPTION
## Description

Added logic to parse and display comment with rich Doxygen support in VS Code hover tooltips. Supports standard tags, inline comments, and Markdown formatting.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] I have tested these changes locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots

https://github.com/user-attachments/assets/e064e90b-9623-453b-aa93-d55e2489aea4

